### PR TITLE
More GTK4 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ distclean:
 
 .PHONY: install
 install: dist
-	gnome-extension install "${DISTNAME}.zip"
+	gnome-extensions install "${DISTNAME}.zip"
 
 .PHONY: test
 test:

--- a/extension.js
+++ b/extension.js
@@ -7,14 +7,25 @@ const Convenience = Me.imports.convenience;
 const Format = Me.imports.formatter;
 
 var settings;
+var last_update;
 
 function init() {
     settings = Convenience.getSettings();
+    last_update = GLib.DateTime.new_now_local();
 }
 
 function overrider(lbl) {
     var FORMAT = settings.get_string("override-string");
     var now = GLib.DateTime.new_now_local();
+
+    // Prevent a really nasty infinite loop if using
+    // invalid or quickly changing format (e.g. %f).
+    // We're limited to 1 second resolution anyway.
+    if (now.difference(last_update) < 500000) {
+        return;
+    }
+
+    last_update = now;
 
     var desired = Format.format(FORMAT, now);
 

--- a/metadata.json.in
+++ b/metadata.json.in
@@ -4,7 +4,8 @@
   "shell-version": [
 	 "40",
 	 "41",
-	 "42"
+	 "42",
+	 "43"
   ],
   "settings-schema": "org.gnome.shell.extensions.clock-override",
   "url": "https://github.com/stuartlangridge/gnome-shell-clock-override",

--- a/prefs.js
+++ b/prefs.js
@@ -98,7 +98,7 @@ const ClockOverrideSettings = new GObject.Class({
                 this.update_textbox_value(eg[1]);
                 grid._settings.set_string('override-string', eg[1]);
                 return true;
-				}));
+            }));
             let r = new Gtk.Label({
                 label: '<tt>' + eg[1] + '</tt>',
                 use_markup: true,
@@ -114,19 +114,12 @@ const ClockOverrideSettings = new GObject.Class({
         });
 
         let label3 = new Gtk.Label({
-            label: '<a href="https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format">' + _("What do all these %x codes mean?") + '</a>',
+            label: '<a href="https://docs.gtk.org/glib/method.DateTime.format.html#description">' + _("What do all these %x codes mean?") + '</a>',
             use_markup: true,
             hexpand: true,
             halign: Gtk.Align.END
         });
         this.attach(label3, 0, rownumber, 3, 1);
-
-
-        this._settings.connect('changed::override-string', Lang.bind(this, function() {
-            let sval = this._settings.get_string('override-string');
-            if (widget.get_text() != sval) widget.set_text(sval);
-        }));
-
     },
 
 });


### PR DESCRIPTION
Hey,

thanks for trying to revive this extension. I have no idea why it's abandoned - for the most part it works nicely on GNOME <= 43.

Changes:
- fixed a typo in your `Makefile`
- updated `metadata.json` to support GNOME 43
- because the new API happily accepts `null` as a parameter to `set_text` instead of raising an error, right now the extension will literally brick your GUI if you input an invalid format string (`overrider` gets called over and over in an infinite loop). I have added a check in order to prevent that.
- removed the `changed::override-string` event since it was causing weird race condition (pressing backspace causes the cursor to go to the beginning of the textbox) and I'm not even sure why it's there in the first place.
- updated the URL for DateTime format explanation

Tested on Ubuntu 22.04 (GNOME 42.9) and Debian 12 (GNOME 43).

I hope somebody pays attention to this and brings the extension back to the public.

Cheers!